### PR TITLE
Ensure all Python code checks are always run

### DIFF
--- a/run_test
+++ b/run_test
@@ -11,7 +11,16 @@ fi
 
 ## Main
 if [ "${RUN_PYTHON_TESTS}" = "true" ]; then
+  python_test_status=0
   run_python_lint "${PYTHON_FILES}"
+  ((python_test_status+=$?))
   run_python_static_analysis "${PYTHON_FILES}"
+  ((python_test_status+=$?))
   run_python_unit_tests "${PYTHON_FILES}"
+  ((python_test_status+=$?))
+
+  if [ "${python_test_status}" != "0" ]; then
+    echo "Failed to pass one or more Python checks"
+    exit ${python_test_status}
+  fi
 fi

--- a/run_test
+++ b/run_test
@@ -12,6 +12,8 @@ fi
 ## Main
 if [ "${RUN_PYTHON_TESTS}" = "true" ]; then
   python_test_status=0
+  set +e
+
   run_python_lint "${PYTHON_FILES}"
   ((python_test_status+=$?))
   run_python_static_analysis "${PYTHON_FILES}"
@@ -23,4 +25,6 @@ if [ "${RUN_PYTHON_TESTS}" = "true" ]; then
     echo "Failed to pass one or more Python checks"
     exit ${python_test_status}
   fi
+
+  set -e
 fi


### PR DESCRIPTION
This PR adjusts the run_test script so that all Python related style, security, and unit tests get run, even if there is a warning or an error. The test script then exits with a non-zero exit code if any of the commands did throw an error.