### PR TITLE
Alpine cache updates

### DIFF
--- a/alpine_setup_functions.inc.sh
+++ b/alpine_setup_functions.inc.sh
@@ -14,7 +14,7 @@ update_system_packages() {
 install_package() {
   local package_name=${1}
 
-  apk add ${1}
+  apk add "${package_name}"
   return $?
 }
 
@@ -31,6 +31,6 @@ add_user() {
   local primary_group="${2}"
   local uid="${3}"
 
-  adduser -u "${3}" -D -S -G "${primary_group}" "${username}"
+  adduser -u "${uid}" -D -S -G "${primary_group}" "${username}"
   return $?
 }

--- a/alpine_setup_functions.inc.sh
+++ b/alpine_setup_functions.inc.sh
@@ -3,6 +3,7 @@
 update_system_packages() {
   apk update
   apk upgrade
+  apk cache clean
 }
 
 install_package() {

--- a/alpine_setup_functions.inc.sh
+++ b/alpine_setup_functions.inc.sh
@@ -1,9 +1,14 @@
 # alpine_setup_functions: Functions used by the run_alpine_setup script
 
 update_system_packages() {
+  local apk_cache_dir="/etc/apk/cache"
+
   apk update
   apk upgrade
-  apk cache clean
+
+  if [ -d "${apk_cache_dir}" ] || [ -L "${apk_cache_dir}" ]; then
+    apk cache clean
+  fi
 }
 
 install_package() {


### PR DESCRIPTION
Check to see if the Alpine instance we are working with is keeping a local package cache.
If so, clear out old packages after the update.

Also, fix a couple of variable references (where I define a local variable and then don't actually use it for some reason).