### PR TITLE
Add get db settings

### DIFF
--- a/get_db_settings_functions.inc.sh
+++ b/get_db_settings_functions.inc.sh
@@ -1,0 +1,12 @@
+# set_db_env_vars.inc.sh: Functions used by the set_db_env_vars script
+
+set_db_env_vars () {
+    local config_file="${1}"
+
+    # Read in and export all name=value pairs where the name starts with PG
+    # (NOTE: all whitespaces are removed from each line)
+    while read -r DBVAR
+    do
+        eval "export ${DBVAR}"
+    done < <(grep -Ee '^PG' "${config_file}" | sed 's/ //g')
+}

--- a/run_get_db_settings.sh
+++ b/run_get_db_settings.sh
@@ -1,0 +1,25 @@
+# get_db_settings: Reads postgres related settings from all of the relevant
+#                  config files and then sets them as environment variables
+
+# Load get_db_settings_functions functions
+source ./script/include/get_db_settings_functions.inc.sh
+
+# Start with the values in the base file
+set_db_env_vars "./config/base.ini"
+
+# If FLASK_ENV is set, and a config file exists for it,
+# allow it to override the defaults
+if [ "${FLASK_ENV}x" != "x" ]; then
+    flask_env_config_file="./config/${FLASK_ENV}.ini"
+
+    if [ -f "${flask_env_config_file}" ]; then
+        set_db_env_vars "${flask_env_config_file}"
+    fi
+fi
+
+# If an OVERRIDE config has been specified, and the file is present, 
+# allow it to override everything else
+if [ ! -z "${OVERRIDE_CONFIG_FULLPATH+is_not_set}" ] && 
+   [ -f "${OVERRIDE_CONFIG_FULLPATH}" ]; then
+    set_db_env_vars "${OVERRIDE_CONFIG_FULLPATH}"
+fi

--- a/run_setup
+++ b/run_setup
@@ -50,7 +50,7 @@ if [ "${RESET_DB}" = "true" ]; then
   if [ -n "${DATABASE_NAME}" ]; then
     echo "Resetting database..."
     # Fetch postgres settings and set them as ENV vars
-    ./script/get_db_settings
+    source ./script/get_db_settings
     # Reset the db
     reset_db "${DATABASE_NAME}"
   else

--- a/run_setup
+++ b/run_setup
@@ -49,6 +49,9 @@ fi
 if [ "${RESET_DB}" = "true" ]; then
   if [ -n "${DATABASE_NAME}" ]; then
     echo "Resetting database..."
+    # Fetch postgres settings and set them as ENV vars
+    ./script/get_db_settings
+    # Reset the db
     reset_db "${DATABASE_NAME}"
   else
     echo "ERROR: RESET_DB is set, but DATABASE_NAME is not!"


### PR DESCRIPTION
This PR adds the ability to process any postgres related settings in the application's INI files and then export them as environment variables.
Those variables can then be used by commands like createdb to properly connect to the specified postgres database.