### PR TITLE
Use PGDATABASE instead of DATABASE_NAME

### DIFF
--- a/run_setup
+++ b/run_setup
@@ -47,14 +47,15 @@ fi
 ./script/bootstrap
 
 if [ "${RESET_DB}" = "true" ]; then
-  if [ -n "${DATABASE_NAME}" ]; then
+  # Fetch postgres settings and set them as ENV vars
+  source ./script/get_db_settings
+
+  if [ -n "${PGDATABASE}" ]; then
     echo "Resetting database..."
-    # Fetch postgres settings and set them as ENV vars
-    source ./script/get_db_settings
     # Reset the db
-    reset_db "${DATABASE_NAME}"
+    reset_db "${PGDATABASE}"
   else
-    echo "ERROR: RESET_DB is set, but DATABASE_NAME is not!"
+    echo "ERROR: RESET_DB is set, but PGDATABASE is not!"
     echo "Skipping database reset..."
   fi
 fi

--- a/run_setup
+++ b/run_setup
@@ -51,7 +51,7 @@ if [ "${RESET_DB}" = "true" ]; then
   source ./script/get_db_settings
 
   if [ -n "${PGDATABASE}" ]; then
-    echo "Resetting database..."
+    echo "Resetting database ${PGDATABASE}..."
     # Reset the db
     reset_db "${PGDATABASE}"
   else

--- a/run_test
+++ b/run_test
@@ -11,14 +11,15 @@ fi
 
 # reset test database
 if [ "${RESET_DB}" = "true" ]; then
-  if [ -n "${DATABASE_NAME}" ]; then
+  # Fetch postgres settings and set them as ENV vars
+  source ./script/get_db_settings
+
+  if [ -n "${PGDATABASE}" ]; then
     echo "Resetting database..."
-    # Fetch postgres settings and set them as ENV vars
-    source ./script/get_db_settings
     # Reset the db
-    reset_db "${DATABASE_NAME}"
+    reset_db "${PGDATABASE}"
   else
-    echo "ERROR: RESET_DB is set, but DATABASE_NAME is not!"
+    echo "ERROR: RESET_DB is set, but PGDATABASE is not!"
     echo "Skipping database reset..."
   fi
 fi

--- a/run_test
+++ b/run_test
@@ -15,7 +15,7 @@ if [ "${RESET_DB}" = "true" ]; then
   source ./script/get_db_settings
 
   if [ -n "${PGDATABASE}" ]; then
-    echo "Resetting database..."
+    echo "Resetting database ${PGDATABASE}..."
     # Reset the db
     reset_db "${PGDATABASE}"
   else


### PR DESCRIPTION
Since we're reading database details from the app configuration, we can rely on PGDATABASE being set instead of also requiring the DATABASE_NAME to be set. 

This fixed an error running tests on Travis on the monolith branch of atst -- the setup script was hard-coding `atat` as the database name, but the CI env file specified `atat-test`. 