### PR TITLE
Env overrides

### DIFF
--- a/get_db_settings_functions.inc.sh
+++ b/get_db_settings_functions.inc.sh
@@ -8,7 +8,7 @@ set_db_env_vars () {
     # (NOTE: all whitespaces are removed from each line)
     while read -r DBVAR
     do
-	if ! $(env | grep -qFle "${DBVAR}"); then
+	if ! $(env | grep -qFle "${DBVAR%%=*}"); then
             eval "export ${DBVAR}"
 	fi
     done < <(grep -Ee '^PG' "${config_file}" | sed 's/ //g')

--- a/get_db_settings_functions.inc.sh
+++ b/get_db_settings_functions.inc.sh
@@ -8,7 +8,7 @@ set_db_env_vars () {
     # (NOTE: all whitespaces are removed from each line)
     while read -r DBVAR
     do
-	if ! $(env | grep -qFle "${foo}"); then
+	if ! $(env | grep -qFle "${DBVAR}"); then
             eval "export ${DBVAR}"
 	fi
     done < <(grep -Ee '^PG' "${config_file}" | sed 's/ //g')

--- a/get_db_settings_functions.inc.sh
+++ b/get_db_settings_functions.inc.sh
@@ -4,9 +4,12 @@ set_db_env_vars () {
     local config_file="${1}"
 
     # Read in and export all name=value pairs where the name starts with PG
+    # unless we already have an env var with that value
     # (NOTE: all whitespaces are removed from each line)
     while read -r DBVAR
     do
-        eval "export ${DBVAR}"
+	if ! $(env | grep -qFle "${foo}"); then
+            eval "export ${DBVAR}"
+	fi
     done < <(grep -Ee '^PG' "${config_file}" | sed 's/ //g')
 }

--- a/run_get_db_settings.sh
+++ b/run_get_db_settings.sh
@@ -4,11 +4,16 @@
 # Load get_db_settings_functions functions
 source ./script/include/get_db_settings_functions.inc.sh
 
-# Start with the values in the base file
-set_db_env_vars "./config/base.ini"
+
+# If an OVERRIDE config has been specified, and the file is present, 
+# read those values first
+if [ ! -z "${OVERRIDE_CONFIG_FULLPATH+is_not_set}" ] && 
+   [ -f "${OVERRIDE_CONFIG_FULLPATH}" ]; then
+    set_db_env_vars "${OVERRIDE_CONFIG_FULLPATH}"
+fi
 
 # If FLASK_ENV is set, and a config file exists for it,
-# allow it to override the defaults
+# allow it to set anything not already defined
 if [ "${FLASK_ENV}x" != "x" ]; then
     flask_env_config_file="./config/${FLASK_ENV}.ini"
 
@@ -17,9 +22,5 @@ if [ "${FLASK_ENV}x" != "x" ]; then
     fi
 fi
 
-# If an OVERRIDE config has been specified, and the file is present, 
-# allow it to override everything else
-if [ ! -z "${OVERRIDE_CONFIG_FULLPATH+is_not_set}" ] && 
-   [ -f "${OVERRIDE_CONFIG_FULLPATH}" ]; then
-    set_db_env_vars "${OVERRIDE_CONFIG_FULLPATH}"
-fi
+# Finish with the base config file, setting anything that is still unset
+set_db_env_vars "./config/base.ini"

--- a/run_setup
+++ b/run_setup
@@ -25,6 +25,11 @@ if [ -z "${RESET_DB+is_set}" ]; then
   RESET_DB="false"
 fi
 
+# If KEEP_EXISTING_VENV is not set, set it to "false"
+if [ -z "${KEEP_EXISTING_VENV+is_set}" ]; then
+  KEEP_EXISTING_VENV="false"
+fi
+
 ## Main
 # Remove any existing node modules as part of initial app setup or reset
 rm -rf ./node_modules
@@ -35,7 +40,14 @@ if [ "${CREATE_VENV}" = "true" ]; then
     echo "ERROR: pipenv is malfunctioning or not present"
     exit 1
   fi
-  create_virtual_environment
+
+  python_version=$(grep python_version ./Pipfile | cut -d '"' -f 2)
+  if ! check_for_existing_virtual_environment "${python_version}" || \
+       [ "${KEEP_EXISTING_VENV}" = "false" ]
+  then
+    create_virtual_environment "${python_version}"
+  fi
+
   pip_install "pip==${PIP_VERSION}" "--upgrade"
 fi
 

--- a/setup_functions.inc.sh
+++ b/setup_functions.inc.sh
@@ -17,16 +17,26 @@ install_pipenv() {
   return "${return_code}"
 }
 
-create_virtual_environment() {
-  default_python_version=3.6
-  # Parse out the required Python version from the Pipfile
-  python_version=$(grep python_version ./Pipfile | cut -d '"' -f 2)
+check_for_existing_virtual_environment() {
+  local python_version="${1}"
+  local target_python_version_regex="^Python ${python_version}"
 
-  # If we ended up with an empty string for the required Python version,
-  # specify the default version
-  if [ -z "${python_version}" ]; then
-    python_version="${default_python_version}"
+  # Check for existing venv, and if one exists, save the Python version string
+  existing_venv_version=$($(pipenv --py) --version)
+  if [ "$?" = "0" ]; then
+    # Existing venv; see if the Python version matches
+    if [[ "${existing_venv_version}" =~ ${target_python_version_regex} ]]; then
+      # Version strings match, valid existing environment is present
+      return 0
+    fi
   fi
+
+  # No valid virtual environment found
+  return 1
+}
+
+create_virtual_environment() {
+  local python_version="${1}"
 
   # Create a new virtual environment for the app
   # The environment will be in a directory called .venv off the app


### PR DESCRIPTION
- Update the function setting DB related environment variables to only set a value if that environment variable does not already exist
- Reverse the order that config files are processed when pulling out DB related variables (override first, env file second, base file third)
- Add the ability to retain an existing virtual environment (assuming it is the same version of Python as the Pipfile requires)