### PR TITLE
Run seed scripts during update and test

### DIFF
--- a/helper_functions.inc.sh
+++ b/helper_functions.inc.sh
@@ -32,6 +32,11 @@ migrate_db() {
   run_command "alembic upgrade head"
 }
 
+seed_db() {
+  run_command "python ./script/seed_roles.py"
+  run_command "python ./script/ingest_pe_numbers.py"
+}
+
 reset_db() {
   local database_name="${1}"
 
@@ -45,4 +50,7 @@ reset_db() {
 
   # Run migrations
   migrate_db
+
+  # Seed database data
+  seed_db
 }

--- a/run_update
+++ b/run_update
@@ -1,4 +1,4 @@
-#  update: Bring an existing application up-to-date 
+#  update: Bring an existing application up-to-date
 #
 
 # Load update functions
@@ -18,3 +18,5 @@ source ./script/bootstrap
 if [ "${MIGRATE_DB}" = "true" ]; then
   migrate_db
 fi
+
+seed_db


### PR DESCRIPTION
Since we're moving fixture data out of our migrations, it makes sense to have some idempotent seed scripts that are run before the app starts. This change causes those scripts to be run.